### PR TITLE
Add share modal and zip downloads per person

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -137,6 +137,14 @@ def build_share_url(names: List[str]) -> str:
 
 def share_button(names: List[str], key: str) -> None:
     if st.button("🔗 Поделиться", key=key):
+        try:
+            st.query_params.clear()
+            st.query_params["root"] = names
+        except Exception:
+            try:
+                st.experimental_set_query_params(root=names)
+            except Exception:
+                pass
         url = build_share_url(names)
         with st.modal("Ссылка для доступа"):
             st.text_input("URL", url, key=f"share_url_{key}")


### PR DESCRIPTION
## Summary
- Add helper for generating share links and display them in a modal
- Support per-person ZIP exports and share buttons
- Provide share link and ZIP download for all selected supervisors
- Preserve built trees when sharing links

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2e858d9d48324849055771cf80065